### PR TITLE
Return the correct WebProtege user id instead of the Keycloak username (fixes #15)

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotegeusermanagement/commands/dto/KeycloakUserRepository.java
+++ b/src/main/java/edu/stanford/protege/webprotegeusermanagement/commands/dto/KeycloakUserRepository.java
@@ -3,6 +3,7 @@ package edu.stanford.protege.webprotegeusermanagement.commands.dto;
 import edu.stanford.protege.webprotege.common.UserId;
 import edu.stanford.protege.webprotegeusermanagement.commands.UserRepository;
 import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.UserRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,6 +19,16 @@ public class KeycloakUserRepository implements UserRepository {
 
     private final static Logger LOGGER = LoggerFactory.getLogger(KeycloakUserRepository.class);
 
+    /**
+     * WebProtégé's application-level user id.  The realm's protocol mapper puts this
+     * attribute into the {@code preferred_username} claim, and the gateway derives the
+     * session {@code UserId} from that claim - so this attribute, not the Keycloak
+     * username, is the identity that permissions must be granted against.  For accounts
+     * created through registration the SPI sets it equal to the Keycloak username; for
+     * legacy migrated accounts it holds the original WebProtégé user name.
+     */
+    public static final String WEBPROTEGE_USERNAME_ATTRIBUTE = "webprotege_username";
+
     private final String realmName;
     private final Keycloak keycloak;
 
@@ -30,13 +41,28 @@ public class KeycloakUserRepository implements UserRepository {
     @Override
     public List<UserId> findUserIdsFromName(String name, boolean exactMatch) {
         try {
+            // briefRepresentation=false so the results carry user attributes; the client
+            // has no overload combining it with exact matching, so exactness is applied
+            // on the username here (matching Keycloak's case-insensitive exact search).
             return keycloak.realm(realmName)
-                    .users().search(name, exactMatch).stream()
-                    .map(userRepresentation -> new UserId(userRepresentation.getUsername()))
+                    .users().search(name, null, null, false).stream()
+                    .filter(user -> !exactMatch || user.getUsername().equalsIgnoreCase(name))
+                    .map(KeycloakUserRepository::toUserId)
                     .collect(Collectors.toList());
         }catch (Exception e) {
             LOGGER.error("Error fetching users ", e);
             return new ArrayList<>();
         }
+    }
+
+    private static UserId toUserId(UserRepresentation user) {
+        var attributes = user.getAttributes();
+        if (attributes != null) {
+            var values = attributes.get(WEBPROTEGE_USERNAME_ATTRIBUTE);
+            if (values != null && !values.isEmpty() && values.get(0) != null && !values.get(0).isBlank()) {
+                return new UserId(values.get(0));
+            }
+        }
+        return new UserId(user.getUsername());
     }
 }

--- a/src/test/java/edu/stanford/protege/webprotegeusermanagement/KeycloakUserRepositoryTest.java
+++ b/src/test/java/edu/stanford/protege/webprotegeusermanagement/KeycloakUserRepositoryTest.java
@@ -13,13 +13,14 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -44,11 +45,26 @@ public class KeycloakUserRepositoryTest {
         repository = new KeycloakUserRepository("webprotege", keycloak);
     }
 
+    private void stubSearch(String term, UserRepresentation... users) {
+        when(userResource.search(eq(term), isNull(), isNull(), eq(false))).thenReturn(Arrays.asList(users));
+    }
+
+    private static UserRepresentation user(String username) {
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername(username);
+        return user;
+    }
+
+    private static UserRepresentation user(String username, String webprotegeUsername) {
+        UserRepresentation user = user(username);
+        user.setAttributes(Map.of(KeycloakUserRepository.WEBPROTEGE_USERNAME_ATTRIBUTE,
+                                  List.of(webprotegeUsername)));
+        return user;
+    }
+
     @Test
     public void GIVEN_anExistingUser_WHEN_queryForUsers_THEN_userIsCorrectlyMapped() {
-        UserRepresentation user = new UserRepresentation();
-        user.setUsername("johndoe");
-        when(userResource.search(eq("john"), eq(false))).thenReturn(Arrays.asList(user));
+        stubSearch("john", user("johndoe"));
 
         List<UserId> response = repository.findUserIdsFromName("john", false);
 
@@ -56,10 +72,40 @@ public class KeycloakUserRepositoryTest {
         assertEquals(1, response.size());
         assertEquals("johndoe", response.get(0).id());
     }
-    
+
+    @Test
+    public void GIVEN_aLegacyUserWithWebprotegeUsernameAttribute_WHEN_queryForUsers_THEN_theAttributeIsReturnedAsTheUserId() {
+        stubSearch("jdoe@x.org", user("jdoe@x.org", "jdoe"));
+
+        List<UserId> response = repository.findUserIdsFromName("jdoe@x.org", true);
+
+        assertEquals(1, response.size());
+        assertEquals("jdoe", response.get(0).id());
+    }
+
+    @Test
+    public void GIVEN_aUserWithoutTheAttribute_WHEN_queryForUsers_THEN_theKeycloakUsernameIsTheFallback() {
+        stubSearch("service-account", user("service-account"));
+
+        List<UserId> response = repository.findUserIdsFromName("service-account", false);
+
+        assertEquals(1, response.size());
+        assertEquals("service-account", response.get(0).id());
+    }
+
+    @Test
+    public void GIVEN_anExactMatchQuery_WHEN_theSearchReturnsInfixHits_THEN_onlyTheExactUsernameSurvives() {
+        stubSearch("anna", user("anna", "anna"), user("joanna", "joanna"));
+
+        List<UserId> response = repository.findUserIdsFromName("anna", true);
+
+        assertEquals(1, response.size());
+        assertEquals("anna", response.get(0).id());
+    }
+
     @Test
     public void GIVEN_missingUser_WHEN_queryForUsers_THEN_responseIsEmpty(){
-        when(userResource.search(eq("alice"), eq(false))).thenReturn(new ArrayList<>());
+        stubSearch("alice");
 
         List<UserId> response = repository.findUserIdsFromName("alice", false);
 
@@ -69,7 +115,7 @@ public class KeycloakUserRepositoryTest {
 
     @Test
     public void GIVEN_exception_WHEN_fetchForUsers_THEN_responseIsEmpty(){
-        when(userResource.search(eq("bob"), eq(false))).thenThrow(new RuntimeException());
+        when(userResource.search(eq("bob"), isNull(), isNull(), eq(false))).thenThrow(new RuntimeException());
 
         List<UserId> response = repository.findUserIdsFromName("bob", false);
 


### PR DESCRIPTION
## Problem

When looking up a person to share a project with, this service reports the Keycloak username as the person's identity. For most users that happens to be correct, because their username and their WebProtege identity are the same string (their email address).

But some accounts were migrated from the old WebProtege and have a different, older identity than their Keycloak username. For those accounts, the two values don't match, and this service was returning the wrong one.

## Impact

Sharing a project with one of these migrated users appeared to work — the account was found, the permission was saved, no error was shown — but the access was actually granted to an identity the person never logs in as. The project silently never showed up in their project list, with nothing anywhere pointing to why.

User search/autocomplete had the same problem: it could suggest a name that doesn't match how that person actually signs in.

## Fix

Look up the account's stored WebProtege identity (kept as a user attribute) and return that instead of the Keycloak username. If an account has no such attribute, the Keycloak username is used as before, so this only changes behavior for the migrated accounts it was wrong for.

## Tests

Added coverage for the migrated-account case, the fallback case, and the existing matching behavior. Full test suite passes.