### PR TITLE
Switch Docker base image to eclipse-temurin (fixes #17)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jre-jammy
 MAINTAINER protege.stanford.edu
 
 EXPOSE 7761


### PR DESCRIPTION
## Problem

Every CI run fails at the Docker-build step, regardless of what the pull request actually changes:

```
ERROR: failed to build: failed to solve: openjdk:17: failed to resolve source metadata
for docker.io/library/openjdk:17: docker.io/library/openjdk:17: not found
```

The official `openjdk` image on Docker Hub no longer publishes a `17` tag.

## Fix

Use `eclipse-temurin`, the actively maintained base image, matching what other WebProtege services already use. Verified locally that the new base image resolves and builds.